### PR TITLE
fix for trailing comma

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -239,8 +239,17 @@ Style/TernaryParentheses:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
-  Enabled: false
+# 複数行の場合はケツカンマを入れる(Arrayリテラル)
+# JSON がケツカンマを許していないという反対意見もあるが、
+# 古い JScript の仕様に縛られる必要は無い。
+# IE9 以降はリテラルでケツカンマ OK なので正しい差分行の検出に寄せる。
+# 2 insertions(+), 1 deletion(-) ではなく、1 insertions
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+# 複数行の場合はケツカンマを入れる(Hashリテラル)
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase

--- a/fincop.gemspec
+++ b/fincop.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '>= 0.52.1'
+  spec.add_dependency 'rubocop', '>= 0.53.0'
   spec.add_dependency 'rubocop-rspec', '>= 1.22.0'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/fincop/version.rb
+++ b/lib/fincop/version.rb
@@ -1,3 +1,3 @@
 module Fincop
-  VERSION = '0.52.1.1'.freeze
+  VERSION = '0.52.1.2'.freeze
 end

--- a/lib/fincop/version.rb
+++ b/lib/fincop/version.rb
@@ -1,3 +1,3 @@
 module Fincop
-  VERSION = '0.52.1.2'.freeze
+  VERSION = '0.53.0.1'.freeze
 end


### PR DESCRIPTION
fincop入れて実行したら↓のエラー起きたので対応しました

https://github.com/bbatsov/rubocop/pull/5307
https://github.com/onk/onkcop/commit/1942502794aa03c410a27b60fe6c52a2f5caf59c


```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in vendor/bundle/ruby/2.4.0/bundler/gems/fincop-2f20413784da/config/rubocop.yml, please update it)
```