### PR TITLE
Bundler/OrderedGems

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -370,3 +370,9 @@ Security/YAMLLoad:
 # extendとかをどこに書くか迷いやすいのでON、ただし問題が多そうなら即OFFにする
 Layout/ClassStructure:
    Enabled: true
+
+#################### Others ################################
+
+# 参考 https://tech.drecom.co.jp/gemfile-style/
+Bundler/OrderedGems:
+  Enabled: true


### PR DESCRIPTION
某地域Ruby会議でも不評だった、Gemfileを辞書順で並べるcopを止めました。
特に意味がないので。。