### PR TITLE
disable RSpec/ContextWording

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -38,3 +38,7 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
    Enabled: false
+
+# 英語力が本当に高くないとつらいので強制はむずい
+RSpec/ContextWording:
+   Enabled: false


### PR DESCRIPTION
英語力が高くないとwhen 〜で成り立つ文章を作るのが大変かつ、読む方も恩恵を預かれない。
そのため、これを一律に強制するのは効果が薄く、効果を高めるために全ての人の英語力を上げるのは現実的ではないのでdisableが妥当かと