### PR TITLE
exclude bin folder

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "db/schema.rb"
     - "node_modules/**/*"
     - "tmp/**/*"
+    - "bin/*"
   DisplayCopNames: true
   DisplayStyleGuide: true
 


### PR DESCRIPTION
bin以下は対象外にする。
多くの場合実行ファイルが置かれるが、そこを直接いじることはまれ
実行したい場合はファイルを直接指定して実行で。