### PR TITLE
rubocop-rails対応

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,6 +1,9 @@
 # Based on onk/onkcop
 # https://github.com/onk/onkcop
 
+require:
+  - rubocop-rails
+
 Rails:
   Enabled: true
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -37,7 +37,7 @@ Layout/IndentFirstHashElement:
 
 # private/protected は一段深くインデントする
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # メソッドチェーン感がより感じられるインデントにする
 Layout/MultilineMethodCallIndentation:

--- a/fincop.gemspec
+++ b/fincop.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '>= 0.68.1'
+  spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec', '>= 1.22.0'
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
## Summary

- rubocop-railsが別gemに切り分けられたので依存gemに追加した
- `Layout/IndentationConsistency` のオプションが変更されたので更新した