### PR TITLE
rubocop_EnforcedStyleを修正しているがversionを変更してないので差分を取得できない

### DIFF
--- a/lib/fincop/version.rb
+++ b/lib/fincop/version.rb
@@ -1,3 +1,3 @@
 module Fincop
-  VERSION = '0.68.1.0'.freeze
+  VERSION = '0.68.1.1'.freeze
 end


### PR DESCRIPTION
varsionが更新されておらず必要な修正が落とせないので、version up

rubocopで落ちる
https://circleci.com/gh/FiNCDeveloper/lifelog_client_ruby/288?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link