### PR TITLE
Follow rubocop changes of v0.80.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -68,10 +68,6 @@ Style/BlockDelimiters:
   Exclude:
     - "spec/**/*"
 
-# option 等、明示的にハッシュにした方が分かりやすい場合もある
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # scope が違うとか親 module の存在確認が必要とかデメリットはあるが、
 # namespace 付きのクラスはかなり頻繁に作るので簡単に書きたい。
 Style/ClassAndModuleChildren:

--- a/fincop.gemspec
+++ b/fincop.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance', '>= 1.5.2'
   spec.add_dependency 'rubocop-rails', '>= 2.4.1'
   spec.add_dependency 'rubocop-rspec', '>= 1.37.0'
-  spec.add_development_dependency 'bundler', '~> 1.17.3'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/fincop.gemspec
+++ b/fincop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '>= 0.79.0'
+  spec.add_dependency 'rubocop', '>= 0.80.0'
   spec.add_dependency 'rubocop-performance', '>= 1.5.2'
   spec.add_dependency 'rubocop-rails', '>= 2.4.1'
   spec.add_dependency 'rubocop-rspec', '>= 1.37.0'

--- a/lib/fincop/version.rb
+++ b/lib/fincop/version.rb
@@ -1,3 +1,3 @@
 module Fincop
-  VERSION = '0.79.0'.freeze
+  VERSION = '0.80.0'.freeze
 end


### PR DESCRIPTION
rubocopのv0.80.0に対応しました

- https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0800-2020-02-18
- rubocop-hq/rubocop#7641

また、合わせて development dependency の bundler のバージョン指定も更新しました