### PR TITLE
Disable RSpec/MultipleMemoizedHelpers

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -43,3 +43,7 @@ RSpec/NestedGroups:
 # 英語力が本当に高くないとつらいので強制はむずい
 RSpec/ContextWording:
    Enabled: false
+
+# 変に`let`を使うことを避けるよりも必要に応じて使用した方が複数の条件での検証などは書きやすい
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/fincop.gemspec
+++ b/fincop.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '>= 0.80.0'
   spec.add_dependency 'rubocop-performance', '>= 1.5.2'
   spec.add_dependency 'rubocop-rails', '>= 2.4.1'
-  spec.add_dependency 'rubocop-rspec', '>= 1.37.0'
+  spec.add_dependency 'rubocop-rspec', '>= 1.43.0'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
表題のcopを無効化する設定を追加しました
(理由はコメントに記載した通りです)
see: https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md#1430-2020-08-17