### PR TITLE
Remove custom Rails/SafeNavigation cop

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -9,10 +9,6 @@ require:
 Rails/NotNullColumn:
   Enabled: false
 
-# method_missing を隠したい場合は respond_to? を使うべき
-Rails/SafeNavigation:
-  ConvertTry: true
-
 # valid? チェックし忘れを防ぎたい
 Rails/SaveBang:
   Enabled: true


### PR DESCRIPTION
`Rails/SafeNavigation`のカスタム設定を削除しました

### 意図・理由

- `try`はactive supportから普通に提供されている機能だし、コメントで書かれているほど忌避する必要があるとは思えない
- **この設定がされていると、`bundle exec rubocop -a`で`.try`が`&.`に変更されてしまう**
  - 本来 `-a`は「互換性のある変更」のみを行うはずなのに、「互換性のない変更がされてしまう」
  - **これが罠すぎるので削除したい**
  - 仮にこのcopを有効にするのが妥当だとしても、このデメリットを許容してまで矯正する必要はないと思っています
(ツール都合ではありますが)