### PR TITLE
Update rake version restriction

### DIFF
--- a/fincop.gemspec
+++ b/fincop.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '>= 2.4.1'
   spec.add_dependency 'rubocop-rspec', '>= 1.43.0'
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
 end


### PR DESCRIPTION
Fix of https://github.com/advisories/GHSA-jppv-gw3r-w3q8

特にバージョンを絞る必要もないと思うので patched version **以降** というバージョン指定に変更しました